### PR TITLE
Move {%s to the left in global host filters

### DIFF
--- a/templates/global_host_filters.py.j2
+++ b/templates/global_host_filters.py.j2
@@ -16,16 +16,16 @@ def per_host_tool_labels( context, label ):
     # Core tools used by all virtual hosts.
     valid_labels = {{ tool_base_labels }}
     general_ngs_labels = {{ tool_ngs_labels }}
-    {% if galaxy_subsites is defined %}
-    {% for subsite in galaxy_subsites %}
+{% if galaxy_subsites is defined %}
+{% for subsite in galaxy_subsites %}
     if "{{ subsite.name }}.{{ galaxy_subsite_base_domain }}" in host:
         valid_labels += general_ngs_labels
-        {% if subsite.extra_tool_labels is defined %}
+{% if subsite.extra_tool_labels is defined %}
         valid_labels += {{ subsite.extra_tool_labels }}
-        {% endif %}
+{% endif %}
         return label.id in valid_labels
-    {% endfor %}
-    {% endif %}        
+{% endfor %}
+{% endif %}        
     return True
 
 BASE_SECTIONS = {{ tool_base_sections }}
@@ -33,11 +33,11 @@ BASE_SECTIONS = {{ tool_base_sections }}
 GENERAL_NGS_SECTIONS = {{ tool_ngs_sections }}
 
 DOMAIN_SECTIONS = {
-    {% if galaxy_subsites is defined %}
-        {% for subdomain in galaxy_subsites %}
-            '{{ subdomain.name }}': GENERAL_NGS_SECTIONS + {{ subdomain.tool_sections }},
-        {% endfor %}
-    {% endif %}    
+{% if galaxy_subsites is defined %}
+{% for subdomain in galaxy_subsites %}
+    '{{ subdomain.name }}': GENERAL_NGS_SECTIONS + {{ subdomain.tool_sections }},
+{% endfor %}
+{% endif %}    
 }
 
 


### PR DESCRIPTION
The whitespace in this template has been causing the filter file to be misaligned, causing an IndentationError from galaxy.  I think this was fixed locally but changes had not been pushed here yet.