### PR TITLE
Update path for base.css

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,13 +42,13 @@
 # Main css file that's used as a fallback.
 - name: Create main site CSS
   ansible.builtin.shell: |
-    cat {{ galaxy_server_dir }}/static/style/base.css {{ galaxy_subsite_dir }}/{{ galaxy_subsite_base_domain }}-custom.css \
+    cat {{ galaxy_server_dir }}/static/dist/base.css {{ galaxy_subsite_dir }}/{{ galaxy_subsite_base_domain }}-custom.css \
       > {{ galaxy_subsite_dir }}/{{ galaxy_subsite_base_domain }}.css
 
 # Make the final CSS files.
 - name: Merge CSS files for subsites
   ansible.builtin.shell: |
-    cat {{ galaxy_server_dir }}/static/style/base.css {{ galaxy_subsite_dir }}/{{ item.name }}.{{ galaxy_subsite_base_domain }}-custom.css \
+    cat {{ galaxy_server_dir }}/static/dist/base.css {{ galaxy_subsite_dir }}/{{ item.name }}.{{ galaxy_subsite_base_domain }}-custom.css \
       > {{ galaxy_subsite_dir }}/{{ item.name }}.{{ galaxy_subsite_base_domain }}.css
   with_items: "{{ galaxy_subsites }}"
 


### PR DESCRIPTION
Given that [static/style/base.css](https://github.com/galaxyproject/galaxy/blob/release_23.0/static/style/base.css) has been a symlink to static/dist/base.css, and that static/dist/base.css also exists on our galaxy that is running release_23.1, this seems like an OK solution.