### PR TITLE
make a variable of base css path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@ galaxy_subsite_default_welcome: "https://galaxyproject.org"
 galaxy_subsite_base_domain: "usegalaxy.org"
 galaxy_subsite_dir: /srv/subsite
 galaxy_subsite_base_css: "#masthead { background-color: #2c3143;}" # Standard Galaxy colour. Override for others
+galaxy_subsite_base_stylesheet: "{{ galaxy_server_dir }}/static/dist/base.css"
 galaxy_subsites: []
 #  - name: test # Accessible at test.usegalaxy.org
 #    brand: Testing

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,13 +42,13 @@
 # Main css file that's used as a fallback.
 - name: Create main site CSS
   ansible.builtin.shell: |
-    cat {{ galaxy_server_dir }}/static/style/base.css {{ galaxy_subsite_dir }}/{{ galaxy_subsite_base_domain }}-custom.css \
+    cat {{ galaxy_subsite_base_stylesheet }} {{ galaxy_subsite_dir }}/{{ galaxy_subsite_base_domain }}-custom.css \
       > {{ galaxy_subsite_dir }}/{{ galaxy_subsite_base_domain }}.css
 
 # Make the final CSS files.
 - name: Merge CSS files for subsites
   ansible.builtin.shell: |
-    cat {{ galaxy_server_dir }}/static/style/base.css {{ galaxy_subsite_dir }}/{{ item.name }}.{{ galaxy_subsite_base_domain }}-custom.css \
+    cat {{ galaxy_subsite_base_stylesheet }} {{ galaxy_subsite_dir }}/{{ item.name }}.{{ galaxy_subsite_base_domain }}-custom.css \
       > {{ galaxy_subsite_dir }}/{{ item.name }}.{{ galaxy_subsite_base_domain }}.css
   with_items: "{{ galaxy_subsites }}"
 


### PR DESCRIPTION
Have a default galaxy_subsite_base_stylesheet: set to "{{ galaxy_server_dir }}/static/dist/base.css" as is done in the tiaas2 repo [here](https://github.com/galaxyproject/ansible-tiaas2/blob/a8594244217ac8aff18a9531cca845ad68d7d383/defaults/main.yml#L24). Note that the previous [static/style/base.css](https://github.com/galaxyproject/galaxy/blob/release_23.0/static/style/base.css) no longer part of the codebase, was already a symlink to static/dist/base.css (also not part of the codebase but will exist once the client is built).